### PR TITLE
Use z in save_tile_by_extent's render_template call

### DIFF
--- a/tile_fetch/core.py
+++ b/tile_fetch/core.py
@@ -306,7 +306,7 @@ def save_tile_by_extent(xmin, ymin, xmax, ymax,
     ----------
     xmin: min x value
     ymin: min y value
-    xmax: max 
+    xmax: max
     output_path: path indicating where tile should be written
 
     Returns
@@ -319,6 +319,6 @@ def save_tile_by_extent(xmin, ymin, xmax, ymax,
         file_path = '{output_path}/{level}/{x}/{y}'.format(
             output_path=output_path, level=level, x=x, y=y
         )
-        tile_url = render_template(template, *tile)
+        tile_url = render_template(template, *tile, z=level)
         save_request(tile_url, file_path)
     return output_path


### PR DESCRIPTION
In `save_tile_by_extent` the call to `render_template` passes a `level` kwarg when it needs to pass a `z` instead. This PR changes it to pass `z`.

This is really just one example of an issue that occurs in a number of places in the code in that both `z` and `level` are used to represent the same thing. Ideally we would choose to use one or the other consistently.